### PR TITLE
Remove the SpeechGrammar constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -222,7 +222,7 @@ interface SpeechRecognitionEvent : Event {
 };
 
 // The object representing a speech grammar
-[Exposed=Window, Constructor]
+[Exposed=Window]
 interface SpeechGrammar {
     attribute DOMString src;
     attribute float weight;


### PR DESCRIPTION
Nothing can be done with these objects, as SpeechGrammarList is
populated using addFromURI/addFromString.

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=26992.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/32.html" title="Last updated on Aug 6, 2018, 10:58 AM GMT (0d9f88d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/32/37047fa...0d9f88d.html" title="Last updated on Aug 6, 2018, 10:58 AM GMT (0d9f88d)">Diff</a>