### PR TITLE
Add MediaStreamTrack support to the Web Speech API spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -158,6 +158,7 @@ interface SpeechRecognition : EventTarget {
 
     // methods to drive the speech interaction
     undefined start();
+    undefined start(MediaStreamTrack audioTrack);
     undefined stop();
     undefined abort();
 
@@ -294,6 +295,9 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
   When the speech input is streaming live through the input media stream, then this start call represents the moment in time that the service must begin to listen and try to match the grammars associated with this request.
   Once the system is successfully listening to the recognition the user agent must raise a start event.
   If the start method is called on an already started object (that is, start has previously been called, and no <a event for=SpeechRecognition>error</a> or <a event for=SpeechRecognition>end</a> event has fired on the object), the user agent must throw an "{{InvalidStateError!!exception}}" {{DOMException}} and ignore the call.</dd>
+
+  <dt><dfn method for=SpeechRecognition>start({{MediaStreamTrack}} audioTrack)</dfn> method</dt>
+  <dd>The overloaded start method does the same thing as the parameterless start method except it performs speech recognition on provided {{MediaStreamTrack}} instead of the input media stream. If the {{MediaStreamTrack/kind}} attribute of the {{MediaStreamTrack}} is not "audio" or the {{MediaStreamTrack/readyState}} attribute is not "live",  the user agent must throw an "{{InvalidStateError!!exception}}" {{DOMException}} and ignore the call.</dd>
 
   <dt><dfn method for=SpeechRecognition>stop()</dfn> method</dt>
   <dd>The stop method represents an instruction to the recognition service to stop listening to more audio, and to try and return a result using just the audio that it has already received for this recognition.


### PR DESCRIPTION
This PR adds MediaStreamSupport to the Web Speech API in the form of an overloaded start method.

Closes #66


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanbliu/speech-api/pull/118.html" title="Last updated on Dec 5, 2024, 10:55 PM UTC (62ae8d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/118/54a3914...evanbliu:62ae8d7.html" title="Last updated on Dec 5, 2024, 10:55 PM UTC (62ae8d7)">Diff</a>