### PR TITLE
Introduce start session algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -316,16 +316,17 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 <dl>
   <dt><dfn method for=SpeechRecognition>start()</dfn> method</dt>
   <dd>
-    1. Let |requestMicrophonePermission| to <code>true</code>.
-    1. Run the <a>start session algorithm</a> with |requestMicrophonePermission|.
+    1. Let <var>requestMicrophonePermission</var> to <code>true</code>.
+    1. Run the <a>start session algorithm</a> with <var>requestMicrophonePermission</var>.
   </dd>
 
   <dt><dfn method for=SpeechRecognition>start({{MediaStreamTrack}} audioTrack)</dfn> method</dt>
   <dd>
-    1. If the {{MediaStreamTrack/kind}} attribute of the {{MediaStreamTrack}} is NOT <code>"audio"</code>, throw an {{InvalidStateError}} and abort these steps.
-    1. If the {{MediaStreamTrack/readyState}} attribute is NOT <code>"live"</code>, throw an {{InvalidStateError}} and abort these steps.
-    1. Let |requestMicrophonePermission| be <code>false</code>.
-    1. Run the <a>start session algorithm</a> with |requestMicrophonePermission|.
+    1. Let <var>audioTrack</var> be the first argument.
+    1. If the <var>audioTrack</var>'s {{MediaStreamTrack/kind}} attribute is NOT <code>"audio"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. If the <var>audioTrack</var>'s {{MediaStreamTrack/readyState}} attribute is NOT <code>"live"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. Let <var>requestMicrophonePermission</var> be <code>false</code>.
+    1. Run the <a>start session algorithm</a> with <var>requestMicrophonePermission</var>.
   </dd>
 
   <dt><dfn method for=SpeechRecognition>stop()</dfn> method</dt>
@@ -350,12 +351,12 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
 </dl>
 
-<p>When the <dfn>start session algorithm</dfn> with |requestMicrophonePermission| is invoked, the user agent MUST run the following steps:
+<p>When the <dfn>start session algorithm</dfn> with <var>requestMicrophonePermission</var> is invoked, the user agent MUST run the following steps:
 
 1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{UnknownError}} and abort these steps.
 1. If {{[[started]]}} is <code>true</code> and no <a event for=SpeechRecognition>error</a> or <a event for=SpeechRecognition>end</a> event has fired, throw an {{InvalidStateError}} and abort these steps.
 1. Set {{[[started]]}} to <code>true</code>.
-1. If |requestMicrophonePermission| is <code>true</code> and [=request permission to use=] "<code>microphone</code>" is [=permission/"denied"=], abort these steps.
+1. If <var>requestMicrophonePermission</var> is <code>true</code> and [=request permission to use=] "<code>microphone</code>" is [=permission/"denied"=], abort these steps.
 1. Once the system is successfully listening to the recognition, [=fire an event=] named <a event for=SpeechRecognition>start</a> at [=this=].
 
 </p>

--- a/index.bs
+++ b/index.bs
@@ -353,7 +353,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
 <p>When the <dfn>start session algorithm</dfn> with <var>requestMicrophonePermission</var> is invoked, the user agent MUST run the following steps:
 
-1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{UnknownError}} and abort these steps.
+1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
 1. If {{[[started]]}} is <code>true</code> and no <a event for=SpeechRecognition>error</a> or <a event for=SpeechRecognition>end</a> event has fired, throw an {{InvalidStateError}} and abort these steps.
 1. Set {{[[started]]}} to <code>true</code>.
 1. If <var>requestMicrophonePermission</var> is <code>true</code> and [=request permission to use=] "<code>microphone</code>" is [=permission/"denied"=], abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -103,7 +103,7 @@ This does not preclude adding support for this as a future API enhancement, and 
   User consent can include, for example:
   <ul>
     <li>User click on a visible speech input element which has an obvious graphical representation showing that it will start speech input.</li>
-    <li>Accepting a permission prompt shown as the result of a call to <code>SpeechRecognition.start</code>.</li>
+    <li>Accepting a permission prompt shown as the result of a call to <a method for=SpeechRecognition>start()</a>.</li>
     <li>Consent previously granted to always allow speech input for this web page.</li>
   </ul>
   </li>
@@ -147,6 +147,14 @@ This does not preclude adding support for this as a future API enhancement, and 
 <p>The speech recognition interface is the scripted web API for controlling a given recognition.</p>
 The term "final result" indicates a SpeechRecognitionResult in which the final attribute is true.
 The term "interim result" indicates a SpeechRecognitionResult in which the final attribute is false.
+
+{{SpeechRecognition}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="SpeechRecognition">
+    : <dfn>[[started]]</dfn>
+    ::
+        A boolean flag representing wether the speech recognition started. The initial value is <code>false</code>.
+</dl>
 
 <pre class="idl">
 [Exposed=Window]
@@ -307,15 +315,18 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
 <dl>
   <dt><dfn method for=SpeechRecognition>start()</dfn> method</dt>
-  <dd>When the start method is called it represents the moment in time the web application wishes to begin recognition.
-  When the speech input is streaming live through the input media stream, then this start call represents the moment in time that the service must begin to listen and try to match the grammars associated with this request.
-  Once the system is successfully listening to the recognition the user agent must raise a start event.
-  If the start method is called on an already started object (that is, start has previously been called, and no <a event for=SpeechRecognition>error</a> or <a event for=SpeechRecognition>end</a> event has fired on the object), the user agent must throw an "{{InvalidStateError!!exception}}" {{DOMException}} and ignore the call.</dd>
+  <dd>
+    1. Let |requestMicrophonePermission| to <code>true</code>.
+    1. Run the <a>start session algorithm</a> with |requestMicrophonePermission|.
+  </dd>
 
   <dt><dfn method for=SpeechRecognition>start({{MediaStreamTrack}} audioTrack)</dfn> method</dt>
-  <dd>The overloaded start method does the same thing as the parameterless start method except it performs speech recognition on provided {{MediaStreamTrack}} instead of the input media stream.
-  If the {{MediaStreamTrack/kind}} attribute of the {{MediaStreamTrack}} is not "audio" or the {{MediaStreamTrack/readyState}} attribute is not "live", the user agent must throw an "{{InvalidStateError!!exception}}" {{DOMException}} and ignore the call.
-  Unlike the parameterless start method, the user agent does not check whether [=this=]'s [=relevant global object=]'s [=associated Document=] is [=allowed to use=] the [=policy-controlled feature=] named "<code>microphone</code>".</dd>
+  <dd>
+    1. If the {{MediaStreamTrack/kind}} attribute of the {{MediaStreamTrack}} is NOT <code>"audio"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. If the {{MediaStreamTrack/readyState}} attribute is NOT <code>"live"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. Let |requestMicrophonePermission| be <code>false</code>.
+    1. Run the <a>start session algorithm</a> with |requestMicrophonePermission|.
+  </dd>
 
   <dt><dfn method for=SpeechRecognition>stop()</dfn> method</dt>
   <dd>The stop method represents an instruction to the recognition service to stop listening to more audio, and to try and return a result using just the audio that it has already received for this recognition.
@@ -338,6 +349,16 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
   <dd>The installOnDeviceSpeechRecognition method returns a boolean indicating whether the installation of on-device speech recognition for a given BCP 47 language tag initiated successfully. [[!BCP47]] Any website can automatically trigger a download of a new language pack if the user is connected to ethernet/Wifi and the language pack matches the user's preferred language. All sites must prompt the user if they wish to trigger a download over a cellular network or a language pack that does not match the user's preferred language.</dd>
 
 </dl>
+
+<p>When the <dfn>start session algorithm</dfn> with |requestMicrophonePermission| is invoked, the user agent MUST run the following steps:
+
+1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{UnknownError}} and abort these steps.
+1. If {{[[started]]}} is <code>true</code> and no <a event for=SpeechRecognition>error</a> or <a event for=SpeechRecognition>end</a> event has fired, throw an {{InvalidStateError}} and abort these steps.
+1. Set {{[[started]]}} to <code>true</code>.
+1. If |requestMicrophonePermission| is <code>true</code> and [=request permission to use=] "<code>microphone</code>" is [=permission/"denied"=], abort these steps.
+1. Once the system is successfully listening to the recognition, [=fire an event=] named <a event for=SpeechRecognition>start</a> at [=this=].
+
+</p>
 
 <h4 id="speechreco-events">SpeechRecognition Events</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -323,8 +323,8 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
   <dt><dfn method for=SpeechRecognition>start({{MediaStreamTrack}} audioTrack)</dfn> method</dt>
   <dd>
     1. Let <var>audioTrack</var> be the first argument.
-    1. If the <var>audioTrack</var>'s {{MediaStreamTrack/kind}} attribute is NOT <code>"audio"</code>, throw an {{InvalidStateError}} and abort these steps.
-    1. If the <var>audioTrack</var>'s {{MediaStreamTrack/readyState}} attribute is NOT <code>"live"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. If <var>audioTrack</var>'s {{MediaStreamTrack/kind}} attribute is NOT <code>"audio"</code>, throw an {{InvalidStateError}} and abort these steps.
+    1. If <var>audioTrack</var>'s {{MediaStreamTrack/readyState}} attribute is NOT <code>"live"</code>, throw an {{InvalidStateError}} and abort these steps.
     1. Let <var>requestMicrophonePermission</var> be <code>false</code>.
     1. Run the <a>start session algorithm</a> with <var>requestMicrophonePermission</var>.
   </dd>

--- a/index.bs
+++ b/index.bs
@@ -153,7 +153,7 @@ The term "interim result" indicates a SpeechRecognitionResult in which the final
 <dl dfn-type=attribute dfn-for="SpeechRecognition">
     : <dfn>[[started]]</dfn>
     ::
-        A boolean flag representing wether the speech recognition started. The initial value is <code>false</code>.
+        A boolean flag representing whether the speech recognition started. The initial value is <code>false</code>.
 </dl>
 
 <pre class="idl">


### PR DESCRIPTION
This PR addresses concerns raised in https://github.com/WebAudio/web-speech-api/pull/135#discussion_r1932985525 and https://github.com/WebAudio/web-speech-api/issues/126#issuecomment-2623897822:
- It makes sure `start()` and `start(MediaStreamTrack audioTrack)` throw if document is not fully active: 
- Request permission to use microphone is called only for `start()`
- A new "start session algorithm" is introduced to formalize how things work when speech recognition starts.

The following tasks have been completed:

 * [ ] Updated web-platform-tests: https://chromium-review.googlesource.com/c/chromium/src/+/6237075

Implementation commitment:

 * [ ] Blink: (link to issue)
 * [ ] Gecko: (link to issue)
 * [ ] WebKit: (link to issue)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-speech-api/pull/138.html" title="Last updated on Feb 17, 2025, 7:39 AM UTC (9fe3ac7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/138/59f74d4...beaufortfrancois:9fe3ac7.html" title="Last updated on Feb 17, 2025, 7:39 AM UTC (9fe3ac7)">Diff</a>