### PR TITLE
Update the on-device speech recognition methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -322,26 +322,26 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
   <dt><dfn method for=SpeechRecognition>availableOnDevice({{DOMString}} lang)</dfn> method</dt>
   <dd>
-    The availableOnDevice method returns a Promise that resolves to a {{AvailabilityStatus}} indicating the on-device speech recognition availability for a given [[!BCP47]] language tag.
+    The {{SpeechRecognition/availableOnDevice}} method returns a {{Promise}} that resolves to a {{AvailabilityStatus}} indicating the on-device speech recognition availability for a given [[!BCP47]] language tag.
 
     When invoked, run these steps:
     1. Let <var>promise</var> be <a>a new promise</a>.
-    1. Return <var>promise</var> and perform the remaining steps in parallel:
-    1. Run the <a>on-device availability algorithm</a> with <var>lang</var> and resolve <var>promise</var> with the result of the algorithm.
+    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>. If it returns an exception, throw it and abort these steps.
+    1. Return <var>promise</var> and resolve it with the result of the <a>on-device availability algorithm</a>.
   </dd>
 
   <dt><dfn method for=SpeechRecognition>installOnDevice({{DOMString}} lang)</dfn> method</dt>
   <dd>
-    The installOnDevice method returns a Promise that resolves to a boolean indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag initiated successfully.
+    The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag initiated successfully.
 
     When invoked, run these steps:
     1. Let <var>promise</var> be <a>a new promise</a>.
-    1. Return <var>promise</var> and perform the remaining steps in parallel:
-    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>.
+    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>. If it returns an exception, throw it and abort these steps.
+    1. Return <var>promise</var>.
     1. If the <a>on-device availability algorithm</a> returns {{AvailabilityStatus/unavailable}}, {{AvailabilityStatus/downloading}}, or {{AvailabilityStatus/available}}, resolve <var>promise</var> with <code>false</code> and skip the rest of these steps.
     1. Initiate the download of the on-device speech recognition language for <var>lang</var>.
         <p class=note>
-          Note: The user agent may prompt the user for explicit permission to download the on-device speech recognition language pack.
+          Note: The user agent can prompt the user for explicit permission to download the on-device speech recognition language pack.
         </p>
     1. If the initiation of the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
   </dd>
@@ -350,10 +350,11 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 <p>When the  <dfn>on-device availability algorithm</dfn> with <var>lang</var> is invoked, the user agent MUST run the following steps:
 1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
 1. If <var>lang</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
-1. If the on-device speech recognition language pack for <var>lang</var> is unsupported, return {{AvailabilityStatus/unavailable}}.
-1. If the on-device speech recognition language pack for <var>lang</var> is supported but not installed, return {{AvailabilityStatus/downloadable}}.
-1. If the on-device speech recognition language pack for <var>lang</var> is downloading, return {{AvailabilityStatus/downloading}}.
-1. If the on-device speech recognition language pack for <var>lang</var> is installed, return {{AvailabilityStatus/available}}.
+1. In parallel, do the following steps:
+    - If the on-device speech recognition language pack for <var>lang</var> is unsupported, return {{AvailabilityStatus/unavailable}}.
+    - If the on-device speech recognition language pack for <var>lang</var> is supported but not installed, return {{AvailabilityStatus/downloadable}}.
+    - If the on-device speech recognition language pack for <var>lang</var> is downloading, return {{AvailabilityStatus/downloading}}.
+    - If the on-device speech recognition language pack for <var>lang</var> is installed, return {{AvailabilityStatus/available}}.
 
 <p>When the <dfn>start session algorithm</dfn> with <var>requestMicrophonePermission</var> is invoked, the user agent MUST run the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -261,7 +261,7 @@ dictionary SpeechRecognitionEventInit : EventInit {
 
   <dt><dfn attribute for=SpeechRecognition>lang</dfn> attribute</dt>
   <dd>This attribute will set the language of the recognition for the request, using a valid BCP 47 language tag. [[!BCP47]]
-  If unset it remains unset for getting in script, but will default to use the <a spec=html>language</a> of the html document root element and associated hierarchy.
+  If unset it remains unset for getting in script, but will default to use the language of the html document root element and associated hierarchy.
   This default value is computed and used when the input request opens a connection to the recognition service.</dd>
 
   <dt><dfn attribute for=SpeechRecognition>continuous</dfn> attribute</dt>
@@ -704,7 +704,7 @@ interface SpeechSynthesisVoice {
 
   <dt><dfn attribute for=SpeechSynthesisUtterance>lang</dfn> attribute</dt>
   <dd>This attribute specifies the language of the speech synthesis for the utterance, using a valid BCP 47 language tag. [[!BCP47]]
-  If unset it remains unset for getting in script, but will default to use the <a spec=html>language</a> of the html document root element and associated hierarchy.
+  If unset it remains unset for getting in script, but will default to use the language of the html document root element and associated hierarchy.
   This default value is computed and used when the input request opens a connection to the recognition service.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisUtterance>voice</dfn> attribute</dt>

--- a/index.bs
+++ b/index.bs
@@ -326,8 +326,8 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
     When invoked, run these steps:
     1. Let <var>promise</var> be <a>a new promise</a>.
-    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>. If it returns an exception, throw it and abort these steps.
-    1. Return <var>promise</var> and resolve it with the result of the <a>on-device availability algorithm</a>.
+    1. Run the <a>on-device availability algorithm</a> with <var>lang</var> and <var>promise</var>. If it returns an exception, throw it and abort these steps.
+    1. Return <var>promise</var>.
   </dd>
 
   <dt><dfn method for=SpeechRecognition>installOnDevice({{DOMString}} lang)</dfn> method</dt>
@@ -335,26 +335,33 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
     The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag initiated successfully.
 
     When invoked, run these steps:
+    1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
+    1. If <var>lang</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
+    1. If the on-device speech recognition language pack for <var>lang</var> is unsupported, return a resolved {{Promise}} with false and skip the rest of these steps.
     1. Let <var>promise</var> be <a>a new promise</a>.
-    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>. If it returns an exception, throw it and abort these steps.
-    1. Return <var>promise</var>.
-    1. If the <a>on-device availability algorithm</a> returns {{AvailabilityStatus/unavailable}}, {{AvailabilityStatus/downloading}}, or {{AvailabilityStatus/available}}, resolve <var>promise</var> with <code>false</code> and skip the rest of these steps.
     1. Initiate the download of the on-device speech recognition language for <var>lang</var>.
         <p class=note>
           Note: The user agent can prompt the user for explicit permission to download the on-device speech recognition language pack.
         </p>
-    1. If the initiation of the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
+    1. [=Queue a task=] on the [=relevant global object=]'s [=task queue=] to run the following step:
+        - If the initiation of the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
+            <p class="note">
+              Note: The <code>false</code> resolution of the Promise does not indicate the specific cause of failure. User agents are encouraged to provide more detailed information about the failure in developer tools console messages. However, this detailed error information is not exposed to the script. This is non-normative.
+            </p>
+    1. Return <var>promise</var>.
   </dd>
 
 </dl>
-<p>When the  <dfn>on-device availability algorithm</dfn> with <var>lang</var> is invoked, the user agent MUST run the following steps:
+<p>When the  <dfn>on-device availability algorithm</dfn> with <var>lang</var> and <var>promise</var> is invoked, the user agent MUST run the following steps:
 1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
 1. If <var>lang</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
-1. In parallel, do the following steps:
-    - If the on-device speech recognition language pack for <var>lang</var> is unsupported, return {{AvailabilityStatus/unavailable}}.
-    - If the on-device speech recognition language pack for <var>lang</var> is supported but not installed, return {{AvailabilityStatus/downloadable}}.
-    - If the on-device speech recognition language pack for <var>lang</var> is downloading, return {{AvailabilityStatus/downloading}}.
-    - If the on-device speech recognition language pack for <var>lang</var> is installed, return {{AvailabilityStatus/available}}.
+1. In parallel, determine the availability status for <var>lang</var>:
+    - If the on-device speech recognition language pack for <var>lang</var> is unsupported, let <var>status</var> be {{AvailabilityStatus/unavailable}}.
+    - Else if the on-device speech recognition language pack for <var>lang</var> is supported but not installed, let <var>status</var> be {{AvailabilityStatus/downloadable}}.
+    - Else if the on-device speech recognition language pack for <var>lang</var> is downloading, let <var>status</var> be {{AvailabilityStatus/downloading}}.
+    - Else if the on-device speech recognition language pack for <var>lang</var> is installed, let <var>status</var> be {{AvailabilityStatus/available}}.
+1. [=Queue a task=] on the [=relevant global object=]'s [=task queue=] to run the following step:
+    - Resolve <var>promise</var> with <var>status</var>.
 
 <p>When the <dfn>start session algorithm</dfn> with <var>requestMicrophonePermission</var> is invoked, the user agent MUST run the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -167,7 +167,7 @@ interface SpeechRecognition : EventTarget {
     undefined start(MediaStreamTrack audioTrack);
     undefined stop();
     undefined abort();
-    static Promise<boolean> availableOnDevice(DOMString lang);
+    static Promise<AvailabilityStatus> availableOnDevice(DOMString lang);
     static Promise<boolean> installOnDevice(DOMString lang);
 
     // event methods
@@ -198,6 +198,13 @@ enum SpeechRecognitionMode {
     "ondevice-preferred", // On-device speech recognition if available, otherwise use Cloud speech recognition as a fallback.
     "ondevice-only", // On-device speech recognition only. Returns an error if on-device speech recognition is not available.
     "cloud-only", // Cloud speech recognition only.
+};
+
+enum AvailabilityStatus {
+    "unavailable",
+    "downloadable",
+    "downloading",
+    "available"
 };
 
 [Exposed=Window]
@@ -314,12 +321,39 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
   If the abort method is called on an object which is already stopped or aborting (that is, start was never called on it, the <a event for=SpeechRecognition>end</a> or <a event for=SpeechRecognition>error</a> event has fired on it, or abort was previously called on it), the user agent must ignore the call.</dd>
 
   <dt><dfn method for=SpeechRecognition>availableOnDevice({{DOMString}} lang)</dfn> method</dt>
-  <dd>The availableOnDevice method returns a Promise that resolves to a boolean indicating whether on-device speech recognition is available for a given BCP 47 language tag. [[!BCP47]]</dd>
+  <dd>
+    The availableOnDevice method returns a Promise that resolves to a {{AvailabilityStatus}} indicating the on-device speech recognition availability for a given [[!BCP47]] language tag.
+
+    When invoked, run these steps:
+    1. Let <var>promise</var> be <a>a new promise</a>.
+    1. Return <var>promise</var> and perform the remaining steps in parallel:
+    1. Run the <a>on-device availability algorithm</a> with <var>lang</var> and resolve <var>promise</var> with the result of the algorithm.
+  </dd>
 
   <dt><dfn method for=SpeechRecognition>installOnDevice({{DOMString}} lang)</dfn> method</dt>
-  <dd>The installOnDevice method returns a Promise that resolves to a boolean indicating whether the installation of on-device speech recognition for a given BCP 47 language tag initiated successfully. [[!BCP47]]</dd>
+  <dd>
+    The installOnDevice method returns a Promise that resolves to a boolean indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag initiated successfully.
+
+    When invoked, run these steps:
+    1. Let <var>promise</var> be <a>a new promise</a>.
+    1. Return <var>promise</var> and perform the remaining steps in parallel:
+    1. Run the <a>on-device availability algorithm</a> with <var>lang</var>.
+    1. If the <a>on-device availability algorithm</a> returns {{AvailabilityStatus/unavailable}}, {{AvailabilityStatus/downloading}}, or {{AvailabilityStatus/available}}, resolve <var>promise</var> with <code>false</code> and skip the rest of these steps.
+    1. Initiate the download of the on-device speech recognition language for <var>lang</var>.
+        <p class=note>
+          Note: The user agent may prompt the user for explicit permission to download the on-device speech recognition language pack.
+        </p>
+    1. If the initiation of the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
+  </dd>
 
 </dl>
+<p>When the  <dfn>on-device availability algorithm</dfn> with <var>lang</var> is invoked, the user agent MUST run the following steps:
+1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
+1. If <var>lang</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
+1. If the on-device speech recognition language pack for <var>lang</var> is unsupported, return {{AvailabilityStatus/unavailable}}.
+1. If the on-device speech recognition language pack for <var>lang</var> is supported but not installed, return {{AvailabilityStatus/downloadable}}.
+1. If the on-device speech recognition language pack for <var>lang</var> is downloading, return {{AvailabilityStatus/downloading}}.
+1. If the on-device speech recognition language pack for <var>lang</var> is installed, return {{AvailabilityStatus/available}}.
 
 <p>When the <dfn>start session algorithm</dfn> with <var>requestMicrophonePermission</var> is invoked, the user agent MUST run the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -332,7 +332,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
   <dt><dfn method for=SpeechRecognition>installOnDevice({{DOMString}} lang)</dfn> method</dt>
   <dd>
-    The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag initiated successfully.
+    The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag succeeded.
 
     When invoked, run these steps:
     1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
@@ -344,7 +344,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
           Note: The user agent can prompt the user for explicit permission to download the on-device speech recognition language pack.
         </p>
     1. [=Queue a task=] on the [=relevant global object=]'s [=task queue=] to run the following step:
-        - If the initiation of the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
+        - If the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
             <p class="note">
               Note: The <code>false</code> resolution of the Promise does not indicate the specific cause of failure. User agents are encouraged to provide more detailed information about the failure in developer tools console messages. However, this detailed error information is not exposed to the script. This is non-normative.
             </p>

--- a/index.bs
+++ b/index.bs
@@ -332,7 +332,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
   <dt><dfn method for=SpeechRecognition>installOnDevice({{DOMString}} lang)</dfn> method</dt>
   <dd>
-    The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} indicating whether the installation of on-device speech recognition for a given [[!BCP47]] language tag succeeded.
+    The {{SpeechRecognition/installOnDevice}} method returns a {{Promise}} that resolves to a {{boolean}} when and whether the installation of on-device speech recognition for a given [[!BCP47]] language tag succeeded.
 
     When invoked, run these steps:
     1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
@@ -346,7 +346,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
     1. [=Queue a task=] on the [=relevant global object=]'s [=task queue=] to run the following step:
         - If the download succeeds, resolve <var>promise</var> with <code>true</code>, otherwise resolve it with <code>false</code>.
             <p class="note">
-              Note: The <code>false</code> resolution of the Promise does not indicate the specific cause of failure. User agents are encouraged to provide more detailed information about the failure in developer tools console messages. However, this detailed error information is not exposed to the script. This is non-normative.
+              Note: The <code>false</code> resolution of the Promise does not indicate the specific cause of failure. User agents are encouraged to provide more detailed information about the failure in developer tools console messages. However, this detailed error information is not exposed to the script.
             </p>
     1. Return <var>promise</var>.
   </dd>
@@ -355,7 +355,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 <p>When the  <dfn>on-device availability algorithm</dfn> with <var>lang</var> and <var>promise</var> is invoked, the user agent MUST run the following steps:
 1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
 1. If <var>lang</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
-1. In parallel, determine the availability status for <var>lang</var>:
+1. Determine the availability status for <var>lang</var>:
     - If the on-device speech recognition language pack for <var>lang</var> is unsupported, let <var>status</var> be {{AvailabilityStatus/unavailable}}.
     - Else if the on-device speech recognition language pack for <var>lang</var> is supported but not installed, let <var>status</var> be {{AvailabilityStatus/downloadable}}.
     - Else if the on-device speech recognition language pack for <var>lang</var> is downloading, let <var>status</var> be {{AvailabilityStatus/downloading}}.


### PR DESCRIPTION
Closes #141

This PR contains the following changes:
 - Introduce a new AvailabilityStatus enum to indicate the availability of on-device speech recognition for a given language.
 - Update the availableOnDevice method to return a Promise that resolves to an AvailabilityStatus instead of a boolean.
 - Rewrite the availableOnDevice and installOnDevice methods in the modern, algorithmic style.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanbliu/speech-api/pull/143.html" title="Last updated on Mar 31, 2025, 6:07 PM UTC (da5f09e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/143/6356249...evanbliu:da5f09e.html" title="Last updated on Mar 31, 2025, 6:07 PM UTC (da5f09e)">Diff</a>