### PR TITLE
Add deprecated grammar support back

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -172,6 +172,7 @@ interface SpeechRecognition : EventTarget {
     constructor();
 
     // recognition parameters
+    attribute SpeechGrammarList grammars;
     attribute DOMString lang;
     attribute boolean continuous;
     attribute boolean interimResults;
@@ -271,6 +272,25 @@ dictionary SpeechRecognitionEventInit : EventInit {
     required SpeechRecognitionResultList results;
 };
 
+// The object representing a speech grammar. This interface has been deprecated and exists in this spec for the sole purpose of maintaining backwards compatibility.
+[Exposed=Window]
+interface SpeechGrammar {
+    attribute DOMString src;
+    attribute float weight;
+};
+
+// The object representing a speech grammar collection. This interface has been deprecated and exists in this spec for the sole purpose of maintaining backwards compatibility.
+[Exposed=Window]
+interface SpeechGrammarList {
+    constructor();
+    readonly attribute unsigned long length;
+    getter SpeechGrammar item(unsigned long index);
+    undefined addFromURI(DOMString src,
+                    optional float weight = 1.0);
+    undefined addFromString(DOMString string,
+                    optional float weight = 1.0);
+};
+
 // The object representing a phrase for contextual biasing.
 [SecureContext, Exposed=Window]
 interface SpeechRecognitionPhrase {
@@ -293,6 +313,10 @@ interface SpeechRecognitionPhraseList {
 <h4 id="speechreco-attributes">SpeechRecognition Attributes</h4>
 
 <dl>
+  <dt><dfn attribute for=SpeechRecognition>grammars</dfn> attribute</dt>
+  <dd>The grammars attribute stores the collection of SpeechGrammar objects which represent the grammars that are active for this recognition. 
+  This attribute does nothing and exists in this spec for the sole purpose of maintaining backwards compatibility.</dd>
+
   <dt><dfn attribute for=SpeechRecognition>lang</dfn> attribute</dt>
   <dd>This attribute will set the language of the recognition for the request, using a valid BCP 47 language tag. [[!BCP47]]
   If unset it remains unset for getting in script, but will default to use the language of the html document root element and associated hierarchy.
@@ -752,6 +776,50 @@ For a non-continuous recognition it will hold only a single value.</p>
         throw a {{RangeError}} and abort these steps.
     1. Remove the {{SpeechRecognitionPhrase}} object at the |index| of {{SpeechRecognitionPhraseList/[[phrases]]}}.
   </dd>
+</dl>
+
+<h4 id="speechreco-speechgrammar">SpeechGrammar</h4>
+
+<p>The SpeechGrammar object represents a container for a grammar.</p>
+<p class=note>Grammar support has been deprecated and removed. The grammar objects remain in the spec for backwards compatibility purposes only and do not affect speech recognition.</p>
+<p>This structure has the following attributes:</p>
+
+<dl>
+  <dt><dfn attribute for=SpeechGrammar>src</dfn> attribute</dt>
+  <dd>The required src attribute is the URI for the grammar.</dd>
+
+  <dt><dfn attribute for=SpeechGrammar>weight</dfn> attribute</dt>
+  <dd>The optional weight attribute controls the weight that the speech recognition service should use with this grammar.
+  By default, a grammar has a weight of 1.
+  Larger weight values positively weight the grammar while smaller weight values make the grammar weighted less strongly.</dd>
+</dl>
+
+<h4 id="speechreco-speechgrammarlist">SpeechGrammarList</h4>
+
+<p>The SpeechGrammarList object represents a collection of SpeechGrammar objects.
+This structure has the following attributes:</p>
+<p class=note>Grammar support has been deprecated and removed. The grammar objects remain in the spec for backwards compatibility purposes only and do not affect speech recognition.</p>
+
+<dl>
+  <dt><dfn attribute for=SpeechGrammarList>length</dfn> attribute</dt>
+  <dd>The length attribute represents how many grammars are currently in the array.</dd>
+
+  <dt><dfn method for=SpeechGrammarList>item(<var>index</var>)</dfn> getter</dt>
+  <dd>The item getter returns a SpeechGrammar from the index into an array of grammars.
+  The user agent must ensure that the length attribute is set to the number of elements in the array.
+  The user agent must ensure that the index order from smallest to largest matches the order in which grammars were added to the array.</dd>
+
+  <dt><dfn method for=SpeechGrammarList>addFromURI(<var>src</var>, <var>weight</var>)</dfn> method</dt>
+  <dd>This method appends a grammar to the grammars array parameter based on URI.
+  The URI for the grammar is specified by the <var>src</var> parameter, which represents the URI for the grammar.
+  Note, some services may support builtin grammars that can be specified by URI.
+  The <var>weight</var> parameter represents this grammar's weight relative to the other grammar.
+
+  <dt><dfn method for=SpeechGrammarList>addFromString(<var>string</var>, <var>weight</var>)</dfn> method</dt>
+  <dd>This method appends a grammar to the grammars array parameter based on text.
+  The content of the grammar is specified by the <var>string</var> parameter.
+  This content should be encoded into a data: URI when the SpeechGrammar object is created.
+  The <var>weight</var> parameter represents this grammar's weight relative to the other grammar.
 </dl>
 
 <h3 id="tts-section">The SpeechSynthesis Interface</h3>


### PR DESCRIPTION
Closes #???

Grammar support was recently [removed](https://github.com/WebAudio/web-speech-api/pull/117) from the Web Speech API spec. While grammar never actually did anything in Chrome, metrics show the number of calls to the WebkitSpeechRecognitionGrammar constructor is ~15% the number of calls to the WebkitSpeechRecognition constructor. We should consider re-adding the grammar section to the spec to maintain backwards compatibility.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanbliu/speech-api/pull/163.html" title="Last updated on Jun 10, 2025, 5:59 PM UTC (ec7b539)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/163/0f9acb0...evanbliu:ec7b539.html" title="Last updated on Jun 10, 2025, 5:59 PM UTC (ec7b539)">Diff</a>