### PR TITLE
Update start session algorithm to fire not-allowed error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -512,8 +512,9 @@ following steps:
         1. Abort these steps.
 1. Set {{[[started]]}} to `true`.
 1. If |requestMicrophonePermission| is `true` and [=request
-    permission to use=] "`microphone`" is [=permission/"denied"=], abort
-    these steps.
+    permission to use=] "`microphone`" is [=permission/"denied"=]:
+    1. [=Queue a task=] to [=fire an event=] named <a event for=SpeechRecognition>error</a> at [=this=] using {{SpeechRecognitionErrorEvent}} with its {{SpeechRecognitionErrorEvent/error}} attribute initialized to {{SpeechRecognitionErrorCode/not-allowed}} and its {{SpeechRecognitionErrorEvent/message}} attribute set to an implementation-defined string detailing the reason.
+    1. Abort these steps.
 1. Once the system is successfully listening to the recognition, queue a task to
     [=fire an event=] named <a event for=SpeechRecognition>start</a> at [=this=].
 


### PR DESCRIPTION
This PR updates the start session algorithm to fire a [not-allowed](https://webaudio.github.io/web-speech-api/#dom-speechrecognitionerrorcode-not-allowed) error if the microphone access request was denied.

Closes #161


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanbliu/speech-api/pull/166.html" title="Last updated on Jun 18, 2025, 11:49 PM UTC (647e101)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/166/59b1992...evanbliu:647e101.html" title="Last updated on Jun 18, 2025, 11:49 PM UTC (647e101)">Diff</a>