### PR TITLE
SpeechRecognitionResult and SpeechRecognitionResultList item() method needs to return a nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -248,7 +248,7 @@ interface SpeechRecognitionAlternative {
 [SecureContext, Exposed=Window]
 interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionAlternative item(unsigned long index);
+    getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
 };
 
@@ -256,7 +256,7 @@ interface SpeechRecognitionResult {
 [SecureContext, Exposed=Window]
 interface SpeechRecognitionResultList {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionResult item(unsigned long index);
+    getter SpeechRecognitionResult? item(unsigned long index);
 };
 
 // A full response, which could be interim or final, part of a continuous response or not


### PR DESCRIPTION
This fixes #178.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/pull/179.html" title="Last updated on Jan 12, 2026, 2:45 PM UTC (b5d80b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/179/895c5dd...b5d80b3.html" title="Last updated on Jan 12, 2026, 2:45 PM UTC (b5d80b3)">Diff</a>