### PR TITLE
Add explicit step for empty langs in install() algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -408,6 +408,7 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
 
     When invoked, run these steps:
     1. If the [=current settings object=]'s [=relevant global object=]'s [=associated Document=] is NOT [=fully active=], throw an {{InvalidStateError}} and abort these steps.
+    1. If {{SpeechRecognitionOptions/langs}} of <var>options</var> is an empty sequence, return a resolved {{Promise}} with false and abort these steps.
     1. If any <var>lang</var> in {{SpeechRecognitionOptions/langs}} of <var>options</var> is not a valid [[!BCP47]] language tag, throw a {{SyntaxError}} and abort these steps.
     1. If the on-device speech recognition language pack for any <var>lang</var> in {{SpeechRecognitionOptions/langs}} of <var>options</var> is unsupported, return a resolved {{Promise}} with false and skip the rest of these steps.
     1. Let <var>promise</var> be <a>a new promise</a>.


### PR DESCRIPTION
The prose already stated that install() should resolve to false when langs is empty, but the algorithm steps didn't include an explicit check. This aligns the algorithm with the prose description.

Fixes #174


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/pull/181.html" title="Last updated on Jan 12, 2026, 3:09 PM UTC (341a766)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/181/895c5dd...341a766.html" title="Last updated on Jan 12, 2026, 3:09 PM UTC (341a766)">Diff</a>