### PR TITLE
chore(deps): bump vnu-jar from ^24.10.17 to ^26.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   },
   "homepage": "https://github.com/WebAudio/web-speech-api#readme",
   "devDependencies": {
-    "vnu-jar": "^24.10.17"
+    "vnu-jar": "^26.7.3"
   }
 }


### PR DESCRIPTION
Resolves the Dependabot SSRF alert for vnu-jar (GHSA-fccg-7w3p-w66f). The pinned ^24.10.17 range resolves to a version in the vulnerable range (<= 26.1.11); ^26.7.3 resolves outside it. Verified the Makefile's node_modules/vnu-jar/build/dist/vnu.jar path still exists in 26.7.3.