### PR TITLE
Update SpeechRecognitionResult with speech timing attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -364,10 +364,10 @@ interface SpeechRecognitionPhrase {
 
 <dl>
   <dt><dfn attribute for=SpeechRecognitionResult>audioStartTime</dfn> attribute</dt>
-  <dd>A nullable {{DOMHighResTimeStamp}} representing the start of the audio segment corresponding to this recognition result, in milliseconds relative to the time origin. Returns null if the underlying recognition engine does not support audio segment start timestamps.</dd>
+  <dd>A nullable {{DOMHighResTimeStamp}} representing the start of the audio segment corresponding to this recognition result, in milliseconds relative to the start of the audio stream. Returns null if the underlying recognition engine does not support audio segment start timestamps.</dd>
 
   <dt><dfn attribute for=SpeechRecognitionResult>audioEndTime</dfn> attribute</dt>
-  <dd>A nullable {{DOMHighResTimeStamp}} representing the end of the audio segment corresponding to this recognition result, in milliseconds relative to the time origin. Returns null if the underlying recognition engine does not support audio segment end timestamps.</dd>
+  <dd>A nullable {{DOMHighResTimeStamp}} representing the end of the audio segment corresponding to this recognition result, in milliseconds relative to the start of the audio stream. Returns null if the underlying recognition engine does not support audio segment end timestamps.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ This does not preclude adding support for this as a future API enhancement, and 
 
   <li>To mitigate the risk of fingerprinting, user agents MUST NOT personalize speech recognition when performing speech recognition on a {{MediaStreamTrack}}.</li>
 
-  <li>To mitigate fingerprinting vectors associated with high-precision timing, user agents MUST apply timestamp fuzzing and precision reduction to {{SpeechRecognitionResult/audioStartTime}} and {{SpeechRecognitionResult/audioEndTime}} before exposing these attributes to scripts (e.g. by rounding to 2ms precision).</li>
+  <li>To mitigate micro-architectural timing attacks and hardware fingerprinting, user agents may reduce the resolution of {{SpeechRecognitionResult/audioStartTime}} and {{SpeechRecognitionResult/audioEndTime}} or introduce jitter, in accordance with the user agent's security and privacy policies (similar to [[HR-TIME-3]] and [[HTML]]).</li>
 </ol>
 
 <h3 id="implementation-considerations">Implementation considerations</h3>
@@ -260,8 +260,8 @@ interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
     getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
-    readonly attribute DOMHighResTimeStamp? audioStartTime;
-    readonly attribute DOMHighResTimeStamp? audioEndTime;
+    readonly attribute double audioStartTime;
+    readonly attribute double audioEndTime;
 };
 
 // A collection of responses (used in continuous mode)
@@ -364,10 +364,10 @@ interface SpeechRecognitionPhrase {
 
 <dl>
   <dt><dfn attribute for=SpeechRecognitionResult>audioStartTime</dfn> attribute</dt>
-  <dd>A nullable {{DOMHighResTimeStamp}} representing the start of the audio segment corresponding to this recognition result, in milliseconds relative to the start of the audio stream. Returns null if the underlying recognition engine does not support audio segment start timestamps.</dd>
+  <dd>A {{double}} representing the start time of the audio segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
 
   <dt><dfn attribute for=SpeechRecognitionResult>audioEndTime</dfn> attribute</dt>
-  <dd>A nullable {{DOMHighResTimeStamp}} representing the end of the audio segment corresponding to this recognition result, in milliseconds relative to the start of the audio stream. Returns null if the underlying recognition engine does not support audio segment end timestamps.</dd>
+  <dd>A {{double}} representing the end time of the audio segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ This does not preclude adding support for this as a future API enhancement, and 
 
   <li>To mitigate the risk of fingerprinting, user agents MUST NOT personalize speech recognition when performing speech recognition on a {{MediaStreamTrack}}.</li>
 
-  <li>To mitigate micro-architectural timing attacks and hardware fingerprinting, user agents may reduce the resolution of {{SpeechRecognitionResult/speechStartTime}} and {{SpeechRecognitionResult/speechEndTime}} or introduce jitter, in accordance with the user agent's security and privacy policies (similar to [[HR-TIME-3]] and [[HTML]]).</li>
+  <li>To mitigate micro-architectural timing attacks and hardware fingerprinting, user agents MAY reduce the resolution of {{SpeechRecognitionResult/speechStartTime}} and {{SpeechRecognitionResult/speechEndTime}} or introduce jitter, in accordance with the user agent's security and privacy policies (similar to [[HR-TIME-3]] and [[HTML]]).</li>
 </ol>
 
 <h3 id="implementation-considerations">Implementation considerations</h3>
@@ -358,16 +358,6 @@ interface SpeechRecognitionPhrase {
   <dd>
     The getter steps are to return the value of {{SpeechRecognition/[[phrases]]}}.
   </dd>
-</dl>
-
-<h4 id="speechrecoresult-attributes">SpeechRecognitionResult Attributes</h4>
-
-<dl>
-  <dt><dfn attribute for=SpeechRecognitionResult>speechStartTime</dfn> attribute</dt>
-  <dd>A {{double}} representing the start time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer (where 0.0 seconds corresponds to the {{SpeechRecognition/onaudiostart}} event).</dd>
-
-  <dt><dfn attribute for=SpeechRecognitionResult>speechEndTime</dfn> attribute</dt>
-  <dd>A {{double}} representing the end time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.
@@ -680,6 +670,12 @@ For example, some implementations may fire <a event for=SpeechRecognition>audioe
   <dt><dfn attribute for=SpeechRecognitionResult>isFinal</dfn> attribute</dt>
   <dd>The final boolean must be set to true if this is the final time the speech service will return this particular index value.
   If the value is false, then this represents an interim result that could still be changed.</dd>
+
+  <dt><dfn attribute for=SpeechRecognitionResult>speechStartTime</dfn> attribute</dt>
+  <dd>A {{double}} representing the start time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer (where 0.0 seconds corresponds to the <a event for=SpeechRecognition>audiostart</a> event).</dd>
+
+  <dt><dfn attribute for=SpeechRecognitionResult>speechEndTime</dfn> attribute</dt>
+  <dd>A {{double}} representing the end time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
 </dl>
 
 <h4 id="speechreco-resultlist">SpeechRecognitionResultList</h4>

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ This does not preclude adding support for this as a future API enhancement, and 
 
   <li>To mitigate the risk of fingerprinting, user agents MUST NOT personalize speech recognition when performing speech recognition on a {{MediaStreamTrack}}.</li>
 
-  <li>To mitigate micro-architectural timing attacks and hardware fingerprinting, user agents may reduce the resolution of {{SpeechRecognitionResult/audioStartTime}} and {{SpeechRecognitionResult/audioEndTime}} or introduce jitter, in accordance with the user agent's security and privacy policies (similar to [[HR-TIME-3]] and [[HTML]]).</li>
+  <li>To mitigate micro-architectural timing attacks and hardware fingerprinting, user agents may reduce the resolution of {{SpeechRecognitionResult/speechStartTime}} and {{SpeechRecognitionResult/speechEndTime}} or introduce jitter, in accordance with the user agent's security and privacy policies (similar to [[HR-TIME-3]] and [[HTML]]).</li>
 </ol>
 
 <h3 id="implementation-considerations">Implementation considerations</h3>
@@ -260,8 +260,8 @@ interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
     getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
-    readonly attribute double audioStartTime;
-    readonly attribute double audioEndTime;
+    readonly attribute double speechStartTime;
+    readonly attribute double speechEndTime;
 };
 
 // A collection of responses (used in continuous mode)
@@ -363,11 +363,11 @@ interface SpeechRecognitionPhrase {
 <h4 id="speechrecoresult-attributes">SpeechRecognitionResult Attributes</h4>
 
 <dl>
-  <dt><dfn attribute for=SpeechRecognitionResult>audioStartTime</dfn> attribute</dt>
-  <dd>A {{double}} representing the start time of the audio segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
+  <dt><dfn attribute for=SpeechRecognitionResult>speechStartTime</dfn> attribute</dt>
+  <dd>A {{double}} representing the start time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer (where 0.0 seconds corresponds to the {{SpeechRecognition/onaudiostart}} event).</dd>
 
-  <dt><dfn attribute for=SpeechRecognitionResult>audioEndTime</dfn> attribute</dt>
-  <dd>A {{double}} representing the end time of the audio segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
+  <dt><dfn attribute for=SpeechRecognitionResult>speechEndTime</dfn> attribute</dt>
+  <dd>A {{double}} representing the end time of the speech segment corresponding to this recognition result, in seconds relative to the start of the audio stream consumed by the speech recognizer.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.

--- a/index.bs
+++ b/index.bs
@@ -120,6 +120,8 @@ This does not preclude adding support for this as a future API enhancement, and 
   <li>The user agent may also give the user a longer explanation the first time speech input is used, to let the user know what it is and how they can tune their privacy settings to disable speech recording if required.</li>
 
   <li>To mitigate the risk of fingerprinting, user agents MUST NOT personalize speech recognition when performing speech recognition on a {{MediaStreamTrack}}.</li>
+
+  <li>To mitigate fingerprinting vectors associated with high-precision timing, user agents MUST apply timestamp fuzzing and precision reduction to {{SpeechRecognitionResult/audioStartTime}} and {{SpeechRecognitionResult/audioEndTime}} before exposing these attributes to scripts (e.g. by rounding to 2ms precision).</li>
 </ol>
 
 <h3 id="implementation-considerations">Implementation considerations</h3>
@@ -258,6 +260,8 @@ interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
     getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
+    readonly attribute DOMHighResTimeStamp? audioStartTime;
+    readonly attribute DOMHighResTimeStamp? audioEndTime;
 };
 
 // A collection of responses (used in continuous mode)
@@ -354,6 +358,16 @@ interface SpeechRecognitionPhrase {
   <dd>
     The getter steps are to return the value of {{SpeechRecognition/[[phrases]]}}.
   </dd>
+</dl>
+
+<h4 id="speechrecoresult-attributes">SpeechRecognitionResult Attributes</h4>
+
+<dl>
+  <dt><dfn attribute for=SpeechRecognitionResult>audioStartTime</dfn> attribute</dt>
+  <dd>A nullable {{DOMHighResTimeStamp}} representing the start of the audio segment corresponding to this recognition result, in milliseconds relative to the time origin. Returns null if the underlying recognition engine does not support audio segment start timestamps.</dd>
+
+  <dt><dfn attribute for=SpeechRecognitionResult>audioEndTime</dfn> attribute</dt>
+  <dd>A nullable {{DOMHighResTimeStamp}} representing the end of the audio segment corresponding to this recognition result, in milliseconds relative to the time origin. Returns null if the underlying recognition engine does not support audio segment end timestamps.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.


### PR DESCRIPTION
Added speechStartTime and speechEndTime attributes to SpeechRecognitionResult interface with explanations as proposed in #191.

Fixes: #191


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alan33d/web-speech-api/pull/192.html" title="Last updated on Sep 11, 2026, 5:32 AM UTC (e3cf78c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/192/291cb48...alan33d:e3cf78c.html" title="Last updated on Sep 11, 2026, 5:32 AM UTC (e3cf78c)">Diff</a>