### PR TITLE
Make SpeechGrammarList.item() nullable.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -256,7 +256,7 @@ interface SpeechRecognitionAlternative {
 [SecureContext, Exposed=Window]
 interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionAlternative item(unsigned long index);
+    getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
 };
 
@@ -264,7 +264,7 @@ interface SpeechRecognitionResult {
 [SecureContext, Exposed=Window]
 interface SpeechRecognitionResultList {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionResult item(unsigned long index);
+    getter SpeechRecognitionResult? item(unsigned long index);
 };
 
 // A full response, which could be interim or final, part of a continuous response or not
@@ -292,7 +292,7 @@ interface SpeechGrammar {
 interface SpeechGrammarList {
     constructor();
     readonly attribute unsigned long length;
-    getter SpeechGrammar item(unsigned long index);
+    getter SpeechGrammar? item(unsigned long index);
     undefined addFromURI(DOMString src,
                     optional float weight = 1.0);
     undefined addFromString(DOMString string,
@@ -769,7 +769,7 @@ This structure has the following attributes:</p>
   <dd>The length attribute represents how many grammars are currently in the array.</dd>
 
   <dt><dfn method for=SpeechGrammarList>item(<var>index</var>)</dfn> getter</dt>
-  <dd>The item getter returns a SpeechGrammar from the index into an array of grammars.
+  <dd>The item getter returns the SpeechGrammar at <var>index</var> in the array of grammars, or null if <var>index</var> is greater than or equal to the length attribute.
   The user agent must ensure that the length attribute is set to the number of elements in the array.
   The user agent must ensure that the index order from smallest to largest matches the order in which grammars were added to the array.</dd>
 


### PR DESCRIPTION
The return type was non-nullable, so an index greater than or equal to length had no valid return value. Chromium declares it non-nullable too, but its implementation returns null for such an index, and other platform collections with an item() getter (NodeList, HTMLCollection, CSSRuleList, FileList) all declare it nullable, so specify null and match what ships.

I'm sending a Gecko patch that includes a WPT for this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/pull/212.html" title="Last updated on Sep 8, 2026, 4:48 PM UTC (3f9e1f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-speech-api/212/bcdfb7f...3f9e1f4.html" title="Last updated on Sep 8, 2026, 4:48 PM UTC (3f9e1f4)">Diff</a>